### PR TITLE
Feature/111 物件エディタ

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ## 参考
 - [Docs](https://photonstorm.github.io/phaser3-docs/)
 - [Phaser.tsチュートリアル](https://magazine.halake.com/entry/phaser-ts-rpg-simple1?utm_source=feed)
+- [テキスト入力プラグイン](https://rexrainbow.github.io/phaser3-rex-notes/docs/site/inputtext/)
 
 ## 詳細
 https://hackmd.io/7j9vigYaTLWDEGgCuyzUvQ

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@types/node": "^16.11.7",
     "fs": "^0.0.1-security",
-    "phaser": "^3.55.2"
+    "phaser": "^3.55.2",
+    "phaser3-rex-plugins": "^1.1.63"
   },
   "devDependencies": {
     "expose-loader": "^3.0.0",

--- a/src/game.ts
+++ b/src/game.ts
@@ -17,6 +17,9 @@ window.addEventListener('load', () => {
         height: Game.height, // 画面高さ
         parent: 'game',      // DOM上の親
         type: Phaser.AUTO,   // canvasかwebGLかを自動選択
-        scene                // 利用するSceneクラス
+        scene,                // 利用するSceneクラス
+        dom: {
+            createContainer: true
+        }
     });
 });

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,6 +1,7 @@
 import "phaser";
 import "./gameData/cards/cards"; // Card より先に import されないとエラーを吐く
 import { TitleScene } from "./scenes/titleScene";
+import InputTextPlugin from 'phaser3-rex-plugins/plugins/inputtext-plugin.js';
 
 export namespace Game{
     export const width = 1280;
@@ -20,6 +21,13 @@ window.addEventListener('load', () => {
         scene,                // 利用するSceneクラス
         dom: {
             createContainer: true
+        },plugins: {
+            global: [{
+                key: 'rexInputTextPlugin',
+                plugin: InputTextPlugin,
+                start: true
+            }
+            ]
         }
     });
 });

--- a/src/gameData/estates/estate.ts
+++ b/src/gameData/estates/estate.ts
@@ -1,6 +1,6 @@
 import { Exportable } from "../../utils/exportable";
-import { FileIO } from "../../utils/fileIO";
 import { StationEstate } from "../stations/stationEstate";
+import { Util } from "../../utils/util";
 
 export type estateData = {
      name: string, price: number, profit: number, isAgri: boolean
@@ -12,12 +12,14 @@ export class Estate implements Exportable{
     readonly price: number;
     readonly profit: number;
     readonly isAgri: boolean;
+    public readonly id: string;
 
     constructor(public data: estateData){
         this.name = data.name;
         this.price = data.price;
         this.profit = data.profit;
         this.isAgri = data.isAgri;
+        this.id = Util.getRandomStringID(4);
     }
 
     final(){

--- a/src/gameData/estates/estate.ts
+++ b/src/gameData/estates/estate.ts
@@ -7,14 +7,13 @@ export type estateData = {
 };
 
 export class Estate implements Exportable{
-    public station: StationEstate;
-    readonly name: string;
-    readonly price: number;
-    readonly profit: number;
-    readonly isAgri: boolean;
+    public name: string;
+    public price: number;
+    public profit: number;
+    public isAgri: boolean;
     public readonly id: string;
 
-    constructor(public data: estateData){
+    constructor(public data: estateData, public station: StationEstate){
         this.name = data.name;
         this.price = data.price;
         this.profit = data.profit;

--- a/src/gameData/field.ts
+++ b/src/gameData/field.ts
@@ -41,14 +41,9 @@ export class Field implements Exportable{
     private importFromJson(name: string){
         const json = FileIO.getJson(name);
         json.forEach((e: stationData & stationEstateData) => {
-            switch(e.type){
-                case 'estate': 
-                    this.add(new stations[e.type](e)); 
-                    break;
-                default: this.add(new stations[e.type](e));
-            }
+            this.add(new stations[e.type](e));
         });
-        json.forEach((e: any) => {
+        json.forEach((e: stationData) => {
             if(e.nexts.up != null){
                 this.connectStationWithID(e.nexts.up, e.id);
             }

--- a/src/gameData/stations/stationEstate.ts
+++ b/src/gameData/stations/stationEstate.ts
@@ -22,14 +22,17 @@ export class StationEstate extends Station{
         if(data != null){
             this.estateData = data;
             for(let v of Object.values(data.estates)){
-                this._estates.push(new Estate(v, this));
+                if(v != null)
+                    this._estates.push(new Estate(v, this));
             }
         }
         
         for(let key in Object.keys(estates)){
             this._estates.push(new Estate(data.estates[key], this));
-        }this.addEstate(new Estate({name: "po", price: 100, profit: 10, isAgri: true}, this));
-        this.addEstate(new Estate({name: "pi", price: 100, profit: 10, isAgri: true}, this));
+        }
+        if(this._estates.length == 0){
+            this.addEstate(new Estate({name: "new Estate", price: 100, profit: 10, isAgri: false}, this));
+        }
     }
     *routine(gameData: GameData): subroutine<void> {
         yield new EventMessage('物件駅に止まった');
@@ -49,6 +52,10 @@ export class StationEstate extends Station{
     }
     changeEstate(estate: Estate){
         this.estateData.estates[estate.id] = estate.data;
+    }
+    removeEstate(index: number){
+        this.estateData.estates[this._estates[index].id] = null;
+        this._estates.splice(index, 1);
     }
     get estates(): Estate[]{
         return this._estates;

--- a/src/gameData/stations/stationEstate.ts
+++ b/src/gameData/stations/stationEstate.ts
@@ -7,11 +7,11 @@ import { estateData} from "../estates/estate";
 
 export type stationEstateData = {
     estates: {
-        [id: number]: estateData;
+        [id: string]: estateData;
     }
   };
 export class StationEstate extends Station{
-    public estates: Estate[];
+    private estates: Estate[];
     public estateData: stationEstateData;
     constructor(data: stationEstateData & stationData, x: number = 0, y: number = 0, z: number = 0, id: number = -1, estates : any = {}){
         super(data, x, y, z, 'estate', id);
@@ -21,14 +21,15 @@ export class StationEstate extends Station{
         }
         if(data != null){
             this.estateData = data;
-            for(let key in Object.keys(data.estates)){
-                this.estates.push(new Estate(data.estates[key]));
+            for(let v of Object.values(data.estates)){
+                this.estates.push(new Estate(v));
             }
         }
         
         for(let key in Object.keys(estates)){
             this.estates.push(new Estate(data.estates[key]));
-        }
+        }this.addEstate(new Estate({name: "po", price: 100, profit: 10, isAgri: true}));
+        this.addEstate(new Estate({name: "pi", price: 100, profit: 10, isAgri: true}));
     }
     *routine(gameData: GameData): subroutine<void> {
         yield new EventMessage('物件駅に止まった');
@@ -41,6 +42,10 @@ export class StationEstate extends Station{
     }
     toJSON(){
         return {...this.data, ...this.estateData};
+    }
+    addEstate(estate: Estate){
+        this.estateData.estates[estate.id] = estate.data;
+        this.estates.push(estate);
     }
 
 }

--- a/src/gameData/stations/stationEstate.ts
+++ b/src/gameData/stations/stationEstate.ts
@@ -11,31 +11,31 @@ export type stationEstateData = {
     }
   };
 export class StationEstate extends Station{
-    private estates: Estate[];
+    private _estates: Estate[];
     public estateData: stationEstateData;
     constructor(data: stationEstateData & stationData, x: number = 0, y: number = 0, z: number = 0, id: number = -1, estates : any = {}){
         super(data, x, y, z, 'estate', id);
-        this.estates = [];
+        this._estates = [];
         this.estateData = {
             estates: {}
         }
         if(data != null){
             this.estateData = data;
             for(let v of Object.values(data.estates)){
-                this.estates.push(new Estate(v));
+                this._estates.push(new Estate(v, this));
             }
         }
         
         for(let key in Object.keys(estates)){
-            this.estates.push(new Estate(data.estates[key]));
-        }this.addEstate(new Estate({name: "po", price: 100, profit: 10, isAgri: true}));
-        this.addEstate(new Estate({name: "pi", price: 100, profit: 10, isAgri: true}));
+            this._estates.push(new Estate(data.estates[key], this));
+        }this.addEstate(new Estate({name: "po", price: 100, profit: 10, isAgri: true}, this));
+        this.addEstate(new Estate({name: "pi", price: 100, profit: 10, isAgri: true}, this));
     }
     *routine(gameData: GameData): subroutine<void> {
         yield new EventMessage('物件駅に止まった');
         yield 'end';
         let message : string = 'この駅の物件は\r\n';
-        this.estates.forEach(e => {message += e.name + " "});
+        this._estates.forEach(e => {message += e.name + " "});
         message += '\r\nです。';
         yield new EventMessage(message);
         yield 'end';
@@ -45,7 +45,13 @@ export class StationEstate extends Station{
     }
     addEstate(estate: Estate){
         this.estateData.estates[estate.id] = estate.data;
-        this.estates.push(estate);
+        this._estates.push(estate);
+    }
+    changeEstate(estate: Estate){
+        this.estateData.estates[estate.id] = estate.data;
+    }
+    get estates(): Estate[]{
+        return this._estates;
     }
 
 }

--- a/src/scenes/editScene.ts
+++ b/src/scenes/editScene.ts
@@ -10,6 +10,7 @@ import { SceneManager } from "../utils/sceneManager";
 import { Util } from "../utils/util";
 import { Layer, Scene } from "./scene";
 import { TitleScene } from "./titleScene";
+import InputText from 'phaser3-rex-plugins/plugins/inputtext.js';
 
 export class EditScene extends Scene{
     private field: Field;
@@ -43,6 +44,36 @@ export class EditScene extends Scene{
         this.field.add(new StationPlus(null, 3, 5));
         this.player = new Player(0);
         this.player.create(this.field.stations[0]);
+
+        
+        var printText = this.add.text(400, 400, '', {
+            fontSize: '20px',
+        }).setOrigin(0.5).setFixedSize(100, 100).setColor('#00ff00');
+        var inputText = new InputText(layer,400, 200, 10, 10, {
+            type: 'textarea',
+            text: 'hello world',
+            fontSize: '18px',});
+        layer.add.existing(inputText);
+        inputText.resize(100, 100)
+            .setOrigin(0.5)
+            .setFontColor('#000000')
+            .on('textchange', function (inputText) {
+                printText.text = inputText.text;
+            })
+            .on('focus', function (inputText) {
+                console.log('On focus');
+            })
+            .on('blur', function (inputText) {
+                console.log('On blur');
+            })
+            .on('click', function (inputText) {
+                console.log('On click');
+            })
+            .on('dblclick', function (inputText) {
+                console.log('On dblclick');
+            })
+
+        printText.text = inputText.text;
     }
     update(){
         KeyManager.update();
@@ -123,3 +154,4 @@ export class EditScene extends Scene{
     }
 }
 
+// https://rexrainbow.github.io/phaser3-rex-notes/docs/site/inputtext/

--- a/src/scenes/editScene.ts
+++ b/src/scenes/editScene.ts
@@ -20,7 +20,8 @@ export class EditScene extends Scene{
     private editStationNum: number = 0;
     private editFlag: boolean = false;
     private editArea: GameObjects.Sprite;
-    private interactiveWindow : InteractiveWindow;
+    public interactiveWindow : InteractiveWindow;
+    estateEditFlag: boolean = false;
 
 
     constructor(){
@@ -45,11 +46,7 @@ export class EditScene extends Scene{
             .setDisplaySize(Field.size, Field.size)
             .setVisible(false)
             .setDepth(100);
-
-        this.field.add(new StationPlus(null, 1, 1));
-        this.field.add(new StationPlus(null, 5, 1));
-        this.field.add(new StationPlus(null, 3, 3));
-        this.field.add(new StationPlus(null, 3, 5));
+        this.field.create('edit');
         this.player = new Player(0);
         this.player.create(this.field.stations[0]);
         this.player.focus();
@@ -61,10 +58,23 @@ export class EditScene extends Scene{
     }
     update(){
         KeyManager.update();
+        if(this.estateEditFlag){
+            if(KeyManager.down('ESC')){
+                this.estateEditFlag = false;
+                this.interactiveWindow.removeData();
+            }
+            return;
+        }
         if(KeyManager.down('CTRL')){
             this.editFlag = Util.xor(this.editFlag, true);
             this.editArea.setVisible(this.editFlag);
             this.editArea.setPosition(this.player.location.x * Field.size, this.player.location.y * Field.size);
+            this.interactiveWindow.removeData();
+            const sta = this.field.getStationByPosition(this.editArea.x / Field.size, this.editArea.y / Field.size);    
+            if(sta != null && sta.stationType == 'estate'){
+                const esta = sta as StationEstate;
+                this.interactiveWindow.setData(this, esta);
+            }
         }
         if(this.editFlag){
             for(const key of Direction.asArray){
@@ -78,7 +88,7 @@ export class EditScene extends Scene{
                     
                     const sta = this.field.getStationByPosition(this.editArea.x / Field.size, this.editArea.y / Field.size);
                     if(sta != null && sta.stationType == 'estate'){
-                        this.interactiveWindow.setData(sta as StationEstate);
+                        this.interactiveWindow.setData(this, sta as StationEstate);
                     }else{
                         this.interactiveWindow.removeData();
                     }
@@ -90,7 +100,7 @@ export class EditScene extends Scene{
                     const s: Station = new stations[Object.keys(stations)[this.editStationNum]](null, this.editArea.x /Field.size, this.editArea.y / Field.size);
                     this.field.add(s);
                     if(s.stationType == 'estate'){
-                        this.interactiveWindow.setData(s as StationEstate);
+                        this.interactiveWindow.setData(this, s as StationEstate);
                     }
                     for(const key of Direction.asArray){
                         const nearSta = this.field.getNearestStation(s,key);
@@ -101,16 +111,6 @@ export class EditScene extends Scene{
                                 this.field.connectStationWithID(s.id, nearSta.id);
                                 this.field.connectStationWithID(s.id, nextSta.id);
                             }
-                        }
-                    }
-                }else{
-                    if(sta.stationType == 'estate'){
-                        const esta = sta as StationEstate;
-                        const layer = SceneManager.layer('field');
-                        for(let i = 0; i < esta.estates.length; i++){
-                            layer.add.text(100, (i + 1) * 50, esta.estates[i].name).setColor('0x000000').setInteractive().on('pointerdown', function(pointer, localX, localY, event){
-                                console.log(`clicked : ${esta.estates[i].name}`);
-                            });;
                         }
                     }
                 }

--- a/src/utils/keyManager.ts
+++ b/src/utils/keyManager.ts
@@ -22,6 +22,7 @@ export class KeyManager {
             this.keys[key] = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes[key]);
             this.counts[key] = 0;
         }
+        scene.input.keyboard.disableGlobalCapture();
         for(const key of this.replaceKeys){
             this.replaceKey(key.key1, key.key2, false);
         }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -27,4 +27,15 @@ export namespace Util{
      export function pick<T>(array: T[]){
         return array[Util.getRandomInt(0, array.length)];
     }
+
+    /** ランダムなIDを取得する
+     * @returns ランダムな文字列
+     */
+     export function getRandomStringID(length: number){
+        let id = '';
+        for(let i = 0; i < length; i++){
+            id += pick<String>('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.split(''));
+        }
+        return id;
+    }
 }

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,6 +1,8 @@
 import InputText from "phaser3-rex-plugins/plugins/inputtext";
+import { setEnvironmentData } from "worker_threads";
 import { Estate } from "../gameData/estates/estate";
 import { StationEstate } from "../gameData/stations/stationEstate";
+import { EditScene } from "../scenes/editScene";
 import { KeyManager } from "./keyManager";
 import { SceneManager } from "./sceneManager";
 
@@ -68,7 +70,13 @@ export class Window{
 
 export class InteractiveWindow{
     private readonly box: Phaser.GameObjects.Rectangle;
-    texts: InputText[];
+    names: InputText[];
+    prices: InputText[];
+    profits: InputText[];
+    isAgris: InputText[];
+    texts: Phaser.GameObjects.Text[];
+    addText: Phaser.GameObjects.Text;
+    removeText: Phaser.GameObjects.Text;
     static margin = 16;
 
     /** 位置・サイズを指定してウィンドウを作成
@@ -86,6 +94,10 @@ export class InteractiveWindow{
         private readonly fontSize: number = 32
     ){
         this.texts = [];
+        this.names = [];
+        this.profits = [];
+        this.isAgris = [];
+        this.prices = [];
         const layer = SceneManager.layer('dialog');
         if(w < 0) w += layer.width - x;
         if(x < 0) x += layer.width - w;
@@ -99,71 +111,148 @@ export class InteractiveWindow{
     }
     final(){
         this.box.destroy();
-        this.texts.forEach(inputText => inputText.destroy());
+        this.texts.forEach(text => text.destroy());
+        this.names.forEach(inputText => inputText.destroy());
+        this.prices.forEach(inputText => inputText.destroy());
+        this.profits.forEach(inputText => inputText.destroy());
+        this.isAgris.forEach(inputText => inputText.destroy());
+        this.addText.destroy();
+        this.removeText.destroy();
     }
 
     private yText(line: number){
         return line * (this.fontSize + Window.margin);
     }
 
-    /** 表示するテキストを設定する
-     * @param texts 表示するテキスト
-     */
-    setTexts(texts: string[]){
-        /*this.messages = texts.map((text, line) => layer.add
-            .text(x + Window.margin, y + this.yText(line) + wFrame, text, { fontSize: `${this.fontSize}px`, color: 'black' })
-            .setPadding(0, Window.margin, 0, 0)
-            .setDepth(1)
-        );*/
-    }
-    setData(station: StationEstate){
+    setData(editScene: EditScene,station: StationEstate){
+        editScene.estateEditFlag = true;
         this.texts = [];
+        this.names = [];
+        this.profits = [];
+        this.isAgris = [];
+        this.prices = [];
         station.estates.forEach(e => {
             this.addData(e);
+        });
+        const layer = SceneManager.layer('dialog');
+        this.addText = layer.add.text(450, 660, 'add').setInteractive();
+        this.addText.on('pointerdown', function (pointer) {
+            station.addEstate(new Estate({name: "new Estate", price: 100, profit: 10, isAgri: false}, station));
+            
+            editScene.interactiveWindow.removeData();
+            editScene.interactiveWindow.setData(editScene, station);
+        });
+        this.setVisible(true);
+
+        this.removeText = layer.add.text(520, 660, 'remove').setInteractive();
+        this.removeText.on('pointerdown', function (pointer) {
+            station.removeEstate(editScene.interactiveWindow.names.length-1);
+            editScene.interactiveWindow.removeData();
+            editScene.interactiveWindow.setData(editScene, station);
         });
         this.setVisible(true);
     }
     addData(estate: Estate){
         const layer = SceneManager.layer('dialog');
-        const inputText = new InputText(layer,100, 100 + this.texts.length * 100, 10, 20, {
+        this.texts.push(layer.add.text(100 + Math.floor(this.names.length / 6) * 250, 60 + (this.names.length % 6) * 100, 'name   : ').setOrigin(0.5));
+        this.texts.push(layer.add.text(100 + Math.floor(this.names.length / 6) * 250, 80 + (this.names.length % 6) * 100, 'price  : ').setOrigin(0.5));
+        this.texts.push(layer.add.text(100 + Math.floor(this.names.length / 6) * 250, 100 + (this.names.length % 6) * 100, 'profit : ').setOrigin(0.5));
+        this.texts.push(layer.add.text(100 + Math.floor(this.names.length / 6) * 250, 120 + (this.names.length % 6) * 100, 'isAgri : ').setOrigin(0.5));
+
+        const name = new InputText(layer, 200 + Math.floor(this.names.length / 6) * 250, 60 + this.names.length % 6 * 100, 10, 30, {
             type: 'textarea',
-            text: estate.name,
-            fontSize: '18px',});
-        layer.add.existing(inputText);
-        inputText.resize(100, 100)
+            text: `${estate.name}`,
+            fontSize: '15px',});
+        layer.add.existing(name);
+        name.resize(100, 20)
             .setOrigin(0.5)
             .setFontColor('#000000')
             .on('textchange', function (inputText) {
                 estate.name = inputText.text;
                 estate.data.name = inputText.text;
                 estate.station.estateData.estates[estate.id] = estate.data;
-            }).on('focus', function (inputText) {
-                console.log('On focus');
-            })
-            .on('blur', function (inputText) {
-                console.log('On blur');
-            })
-            .on('click', function (inputText) {
-                //KeyManager.initNodata(SceneManager.layer('dialog'));
-                console.log('On click');
-            })
-            .on('dblclick', function (inputText) {
-                console.log('On dblclick');
             });
-        this.texts.push(inputText);
+        
+        
+        this.names.push(name);
+
+        const price = new InputText(layer, 200 + Math.floor(this.prices.length / 6) * 250, 80 + this.prices.length % 6 * 100, 10, 15, {
+            type: 'number',
+            text: `${estate.price}`,
+            fontSize: '15px',});
+        layer.add.existing(price);
+        price.resize(100, 20)
+            .setOrigin(0.5)
+            .setFontColor('#000000')
+            .on('textchange', function (inputText) {
+                estate.price = parseInt(inputText.text);
+                estate.data.price = parseInt(inputText.text);
+                estate.station.estateData.estates[estate.id] = estate.data;
+            });
+        
+        
+        this.prices.push(price);
+
+        const profit = new InputText(layer, 200 + Math.floor(this.profits.length / 6) * 250, 100 + this.profits.length % 6 * 100, 10, 15, {
+            type: 'number',
+            text: `${estate.profit}`,
+            fontSize: '15px',});
+        layer.add.existing(profit);
+        profit.resize(100, 20)
+            .setOrigin(0.5)
+            .setFontColor('#000000')
+            .on('textchange', function (inputText) {
+                estate.profit = parseInt(inputText.text);
+                estate.data.profit = parseInt(inputText.text);
+                estate.station.estateData.estates[estate.id] = estate.data;
+            });
+        
+        
+        this.profits.push(profit);
+
+        const isAgri = new InputText(layer, 200 + Math.floor(this.isAgris.length / 6) * 250, 120 + this.isAgris.length % 6 * 100, 10, 15, {
+            type: 'textArea',
+            text: `${estate.isAgri}`,
+            fontSize: '15px',});
+        layer.add.existing(isAgri);
+        isAgri.resize(100, 20)
+            .setOrigin(0.5)
+            .setFontColor('#000000')
+            .on('textchange', function (inputText) {
+                estate.isAgri = (inputText == 'true' ) ? true : false;
+                estate.data.isAgri = estate.isAgri;
+                estate.station.estateData.estates[estate.id] = estate.data;
+            });
+        
+        
+        this.isAgris.push(isAgri);
     }
     removeData(){
         this.texts.forEach(e =>{
             e.destroy();
+        });this.names.forEach(e =>{
+            e.destroy();
+        });this.prices.forEach(e =>{
+            e.destroy();
+        });this.profits.forEach(e =>{
+            e.destroy();
+        });this.isAgris.forEach(e =>{
+            e.destroy();
         });
         this.texts = [];
+        this.names = [];
+        this.profits = [];
+        this.isAgris = [];
+        this.prices = [];
+        this.addText?.destroy();
+        this.removeText?.destroy();
         this.setVisible(false);
     }
 
     /** 画面下に表示される、3 行のテキストボックス */
     static side(){
         const margin = 30;
-        return new InteractiveWindow(margin, margin, 300, SceneManager.layer('dialog').height - margin * 2);
+        return new InteractiveWindow(margin, margin, 560, SceneManager.layer('dialog').height - margin * 2);
     }
     setVisible(visible: boolean){
         this.box.setVisible(visible);

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,3 +1,7 @@
+import InputText from "phaser3-rex-plugins/plugins/inputtext";
+import { Estate } from "../gameData/estates/estate";
+import { StationEstate } from "../gameData/stations/stationEstate";
+import { KeyManager } from "./keyManager";
 import { SceneManager } from "./sceneManager";
 
 export class Window{
@@ -59,5 +63,109 @@ export class Window{
     static lower(){
         const margin = 30;
         return new Window(margin, -margin, -margin, 3);
+    }
+}
+
+export class InteractiveWindow{
+    private readonly box: Phaser.GameObjects.Rectangle;
+    texts: InputText[];
+    static margin = 16;
+
+    /** 位置・サイズを指定してウィンドウを作成
+     * @param x ウィンドウ左上の `x` 座標（負値を指定すると、画面右端が基準になる）
+     * @param y ウィンドウ左上の `y` 座標（負値を指定すると、画面下端が基準になる）
+     * @param w ウィンドウの幅（負値を指定すると、画面右端からの距離）
+     * @param texts ウィンドウに表示する行ごとのテキスト、またはその行数
+     * @param fornSize フォントの大きさ
+     */
+    constructor(
+        x: number,
+        y: number,
+        w: number,
+        h: number,
+        private readonly fontSize: number = 32
+    ){
+        this.texts = [];
+        const layer = SceneManager.layer('dialog');
+        if(w < 0) w += layer.width - x;
+        if(x < 0) x += layer.width - w;
+        if(y < 0) y += layer.height - h;
+        
+        const wFrame = 4;
+        this.box = layer.add
+            .rectangle(x - wFrame, y - wFrame, w + 2*wFrame, h + 2*wFrame, 0x000088, 0.5)
+            .setStrokeStyle(wFrame, 0x080808)
+            .setOrigin(0);
+    }
+    final(){
+        this.box.destroy();
+        this.texts.forEach(inputText => inputText.destroy());
+    }
+
+    private yText(line: number){
+        return line * (this.fontSize + Window.margin);
+    }
+
+    /** 表示するテキストを設定する
+     * @param texts 表示するテキスト
+     */
+    setTexts(texts: string[]){
+        /*this.messages = texts.map((text, line) => layer.add
+            .text(x + Window.margin, y + this.yText(line) + wFrame, text, { fontSize: `${this.fontSize}px`, color: 'black' })
+            .setPadding(0, Window.margin, 0, 0)
+            .setDepth(1)
+        );*/
+    }
+    setData(station: StationEstate){
+        this.texts = [];
+        station.estates.forEach(e => {
+            this.addData(e);
+        });
+        this.setVisible(true);
+    }
+    addData(estate: Estate){
+        const layer = SceneManager.layer('dialog');
+        const inputText = new InputText(layer,100, 100 + this.texts.length * 100, 10, 20, {
+            type: 'textarea',
+            text: estate.name,
+            fontSize: '18px',});
+        layer.add.existing(inputText);
+        inputText.resize(100, 100)
+            .setOrigin(0.5)
+            .setFontColor('#000000')
+            .on('textchange', function (inputText) {
+                estate.name = inputText.text;
+                estate.data.name = inputText.text;
+                estate.station.estateData.estates[estate.id] = estate.data;
+            }).on('focus', function (inputText) {
+                console.log('On focus');
+            })
+            .on('blur', function (inputText) {
+                console.log('On blur');
+            })
+            .on('click', function (inputText) {
+                //KeyManager.initNodata(SceneManager.layer('dialog'));
+                console.log('On click');
+            })
+            .on('dblclick', function (inputText) {
+                console.log('On dblclick');
+            });
+        this.texts.push(inputText);
+    }
+    removeData(){
+        this.texts.forEach(e =>{
+            e.destroy();
+        });
+        this.texts = [];
+        this.setVisible(false);
+    }
+
+    /** 画面下に表示される、3 行のテキストボックス */
+    static side(){
+        const margin = 30;
+        return new InteractiveWindow(margin, margin, 300, SceneManager.layer('dialog').height - margin * 2);
+    }
+    setVisible(visible: boolean){
+        this.box.setVisible(visible);
     }
 }


### PR DESCRIPTION
staticのアップデートとnpm iをしてからデバッグしてみて欲しい
## 使い方
- タイトルでCTRL+SHIFT+E
- CTRLで線路を引くモードと駅の編集モードを変更(線路を引くモードは今後なくなる予定です)
- 線路を引くのはSHIFT＋方向キー
- 駅を置くのはZ
- 駅を消すのはX(線路を引く人がいる駅は消せません)
- 置く駅を変えるのはC
- 物件駅の編集は該当のテキストを編集してください
- 物件駅の編集モード時はESC以外のキーが利かなくなります(物件駅の編集を終えるときはESC)